### PR TITLE
Allow client to use IAM role attached to EC2 instance

### DIFF
--- a/internal/services/awsservice/instance.go
+++ b/internal/services/awsservice/instance.go
@@ -250,23 +250,24 @@ func (inst *Instance) done() bool {
 
 // createSession returns a new aws session using configured aws information.
 func (inst *Instance) createSession(region string) (*session.Session, error) {
-	var creds *credentials.Credentials
+	var cfg *aws.Config
 
 	switch {
 	case inst.cfg.AWS.Role != "":
-		creds = credentials.NewSharedCredentials(
+		creds := credentials.NewSharedCredentials(
 			inst.cfg.AWS.CredentialsFile,
 			inst.cfg.AWS.Role)
+		cfg = &aws.Config{Credentials: creds}
 	case inst.cfg.AWS.AccessKeyID != "":
-		creds = credentials.NewStaticCredentials(
+		creds := credentials.NewStaticCredentials(
 			inst.cfg.AWS.AccessKeyID,
 			inst.cfg.AWS.SecretAccessKey,
 			"")
+		cfg = &aws.Config{Credentials: creds}
 	default:
-		return nil, errors.New("invalid AWS credentils configuration")
+		cfg = &aws.Config{}
 	}
 
-	cfg := &aws.Config{Credentials: creds}
 	if region != "" && region != "global" {
 		cfg.Region = aws.String(region)
 	}


### PR DESCRIPTION
I would like to be able to use the circonus cloud agent via an ec2 role attachment instead of having to explicitly provide a credential file or the access/secret keys. The go aws sdk supports this through the default credential chain. This change was tested on two ec2 instances. One had a role with the permissions outlined [here](https://docs.circonus.com/circonus/integrations/agents/circonus-cloud-agent/#aws). The other had no role attachments.

For the ec2 instance with the role attachment, collection proceeded as normal. As a side benefit,  it also used the default aws credentials for my local osx machine as well.

For the ec2 instance without the role attachment, collection did not occur. However, in this PR, it is a soft failure, with the following error message appearing for each collection interval:

```json
{"level":"warn","pkg":"aws","id":"wkrause2","region":"us-east-1","error":"getting instance information: NoCredentialProviders: no valid providers in chain. Deprecated.\n\tFor verbose messaging see aws.Config.CredentialsChainVerboseErrors","collector":"AWS/EC2","time":"2022-03-26T21:58:53.002445293Z","message":"collecting telemetry"}
```

To preserve backwards compatibility, you may wish to make the use of the IAM role credentials as a flag in the config file so there is a hard failure if the keys or credential files are not present and the iam role flag is not true. This was more just a proof of concept since using ec2 iam role attachments is generally considered a more secure way to interface with AWS resources. 
